### PR TITLE
Use systemd to launch and restart kivy app

### DIFF
--- a/stage2-custom/04-ccu-app/00-run.sh
+++ b/stage2-custom/04-ccu-app/00-run.sh
@@ -12,10 +12,8 @@ on_chroot << EOF
 chown -R ${FIRST_USER_NAME}:${FIRST_USER_NAME} /home/${FIRST_USER_NAME}
 EOF
 
-# Configure crontab
+# Install ccu-app service
+install -m 644 files/ccu-app.service	"${ROOTFS_DIR}/etc/systemd/system/"
 on_chroot << EOF
-until cat /var/spool/cron/crontabs/${FIRST_USER_NAME} | grep ${app_name}; do
-  (crontab -u ${FIRST_USER_NAME} -l; echo "@reboot /usr/bin/python3 /home/${FIRST_USER_NAME}/${app_name}/main.py") | crontab -u ${FIRST_USER_NAME} -
-  sleep 1
-done
+systemctl enable ccu-app
 EOF

--- a/stage2-custom/04-ccu-app/files/ccu-app.service
+++ b/stage2-custom/04-ccu-app/files/ccu-app.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Runs the kivy app that can be used to control the DCUs on the CCU
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/python3 /home/pi/DCU-central-control-app/main.py
+RestartSec=5
+Restart=always
+User=pi
+
+[Install]
+WantedBy=graphical.target
+


### PR DESCRIPTION
Zorgt ervoor dat kivy ook opnieuw opstart bij een crash en dat we logs via journalctl kunnen inzien. 